### PR TITLE
Fix corner radius ambiguity issue

### DIFF
--- a/PopupDialog/Classes/PopupDialogContainerView.swift
+++ b/PopupDialog/Classes/PopupDialogContainerView.swift
@@ -48,6 +48,11 @@ final public class PopupDialogContainerView: UIView {
         }
     }
     
+    /// Alias method for `cornerRadius` variable to avoid ambiguity.
+    @objc public dynamic func setupCornerRadius(_ radius: Float) {
+        self.cornerRadius = radius
+    }
+
     // MARK: Shadow related
 
     /// Enable / disable shadow rendering of the container

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The container view contains the PopupDialogDefaultView or your custom view contr
 let containerAppearance = PopupDialogContainerView.appearance()
 
 containerAppearance.backgroundColor = UIColor(red:0.23, green:0.23, blue:0.27, alpha:1.00)
-containerAppearance.cornerRadius    = 2
+containerAppearance.cornerRadius    = 2     // Use `containerAppearance.setupCornerRadius(2)` instead if you define `cornerRadius` property in `UIView`
 containerAppearance.shadowEnabled   = true
 containerAppearance.shadowColor     = .black
 containerAppearance.shadowOpacity   = 0.6


### PR DESCRIPTION
This issue happens when user already defined `cornerRadius` property in `UIView` extension.