### PR TITLE
Fixing corner radius issue, adding iPhones preferred width and custom margins

### DIFF
--- a/PopupDialog/Classes/PopupDialogContainerView.swift
+++ b/PopupDialog/Classes/PopupDialogContainerView.swift
@@ -48,6 +48,11 @@ final public class PopupDialogContainerView: UIView {
         }
     }
     
+    /// Alias method for `cornerRadius` variable to avoid ambiguity.
+    @objc public dynamic func setupCornerRadius(_ radius: Float) {
+        self.cornerRadius = radius
+    }
+
     // MARK: Shadow related
 
     /// Enable / disable shadow rendering of the container

--- a/PopupDialog/Classes/PopupDialogContainerView.swift
+++ b/PopupDialog/Classes/PopupDialogContainerView.swift
@@ -175,11 +175,11 @@ final public class PopupDialogContainerView: UIView {
         var constraints = [NSLayoutConstraint]()
 
         // Shadow container constraints
+        let metrics = ["preferredWidth": preferredWidth]
         if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad {
-            let metrics = ["preferredWidth": preferredWidth]
             constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(>=40)-[shadowContainer(==preferredWidth@900)]-(>=40)-|", options: [], metrics: metrics, views: views)
         } else {
-            constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(>=10,==20@900)-[shadowContainer(<=340,>=300)]-(>=10,==20@900)-|", options: [], metrics: nil, views: views)
+            constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(>=10)-[shadowContainer(==preferredWidth@900)]-(>=10)-|", options: [], metrics: metrics, views: views)
         }
         constraints += [NSLayoutConstraint(item: shadowContainer, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)]
         centerYConstraint = NSLayoutConstraint(item: shadowContainer, attribute: .centerY, relatedBy: .equal, toItem: self, attribute: .centerY, multiplier: 1, constant: 0)

--- a/PopupDialog/Classes/PopupDialogDefaultView.swift
+++ b/PopupDialog/Classes/PopupDialogDefaultView.swift
@@ -103,6 +103,18 @@ final public class PopupDialogDefaultView: UIView {
     /// The height constraint of the image view, 0 by default
     internal var imageHeightConstraint: NSLayoutConstraint?
 
+    /// The margin constraint between image view top and `PopupDialogDefaultView` top
+    internal var imageTopMarginConstraint: NSLayoutConstraint!
+
+    /// The margin constraint between title label top and image view bottom
+    internal var titleTopMarginConstraint: NSLayoutConstraint!
+    
+    /// The margin constraint between message label top and title label bottom
+    internal var messageTopMarginConstraint: NSLayoutConstraint!
+
+    /// The margin constraint between message label bottom and `PopupDialogDefaultView` bottom
+    internal var messageBottomMarginConstraint: NSLayoutConstraint!
+
     // MARK: - Initializers
 
     internal override init(frame: CGRect) {
@@ -133,8 +145,21 @@ final public class PopupDialogDefaultView: UIView {
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|[imageView]|", options: [], metrics: nil, views: views)
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(==20@900)-[titleLabel]-(==20@900)-|", options: [], metrics: nil, views: views)
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(==20@900)-[messageLabel]-(==20@900)-|", options: [], metrics: nil, views: views)
-        constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|[imageView]-(==30@900)-[titleLabel]-(==8@900)-[messageLabel]-(==30@900)-|", options: [], metrics: nil, views: views)
         
+        // Image view top margin constraint
+        imageTopMarginConstraint = .init(item: imageView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1, constant: 0)
+
+        // Title label top margin constraint
+        titleTopMarginConstraint = .init(item: titleLabel, attribute: .top, relatedBy: .equal, toItem: imageView, attribute: .bottom, multiplier: 1, constant: 30)
+
+        // Message label top margin constraint
+        messageTopMarginConstraint = .init(item: messageLabel, attribute: .top, relatedBy: .equal, toItem: titleLabel, attribute: .bottom, multiplier: 1, constant: 8)
+
+        // Message label bottom constraint
+        messageBottomMarginConstraint = .init(item: self, attribute: .bottom, relatedBy: .equal, toItem: messageLabel, attribute: .bottom, multiplier: 1, constant: 30)
+
+        constraints += [imageTopMarginConstraint, titleTopMarginConstraint, messageTopMarginConstraint, messageBottomMarginConstraint]
+
         // ImageView height constraint
         imageHeightConstraint = NSLayoutConstraint(item: imageView, attribute: .height, relatedBy: .equal, toItem: imageView, attribute: .height, multiplier: 0, constant: 0)
         

--- a/PopupDialog/Classes/PopupDialogDefaultViewController.swift
+++ b/PopupDialog/Classes/PopupDialogDefaultViewController.swift
@@ -70,6 +70,40 @@ public extension PopupDialogDefaultViewController {
         }
     }
 
+    // MARK: Margins
+
+    /// The margin between image and super view top
+    var imageTopMargin: CGFloat {
+        get { return standardView.imageTopMarginConstraint.constant }
+        set {
+            standardView.imageTopMarginConstraint.constant = newValue
+        }
+    }
+
+    /// The margin between title and image
+    var titleTopMargin: CGFloat {
+        get { return standardView.titleTopMarginConstraint.constant }
+        set {
+            standardView.titleTopMarginConstraint.constant = newValue
+        }
+    }
+
+    /// The margin between message and title
+    var messageTopMargin: CGFloat {
+        get { return standardView.messageTopMarginConstraint.constant }
+        set {
+            standardView.messageTopMarginConstraint.constant = newValue
+        }
+    }
+
+    /// The margin between message and buttons view
+    var messageBottomMargin: CGFloat {
+        get { return standardView.messageBottomMarginConstraint.constant }
+        set {
+            standardView.messageBottomMarginConstraint.constant = newValue
+        }
+    }
+    
     // MARK: Appearance
 
     /// The font and size of the title label

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The container view contains the PopupDialogDefaultView or your custom view contr
 let containerAppearance = PopupDialogContainerView.appearance()
 
 containerAppearance.backgroundColor = UIColor(red:0.23, green:0.23, blue:0.27, alpha:1.00)
-containerAppearance.cornerRadius    = 2
+containerAppearance.cornerRadius    = 2     // Use `containerAppearance.setupCornerRadius(2)` instead if you define `cornerRadius` property in `UIView`
 containerAppearance.shadowEnabled   = true
 containerAppearance.shadowColor     = .black
 containerAppearance.shadowOpacity   = 0.6

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ public enum PopupDialogTransitionStyle: Int {
 
 ## Preferred Width
 
-PopupDialog will always try to have a max width of 340 . On iPhones with smaller screens, like iPhone 5 SE, width would be 320.
-340 is also the standard width for iPads. By setting preferredWidth you can override the max width of 340 for iPads only.
+PopupDialog will always try to have a max width of 340 . On iPhones with smaller screens, like iPhone 5 SE, width would be 300.
+340 is also the standard width for iPads. By setting preferredWidth you can override this max width.
 
 ## Gesture Dismissal
 


### PR DESCRIPTION
- Fix corner radius ambiguity issue when user has already defined `cornerRadius` in `UIView`.
- Support preferred width in iPhones.
- Support custom margins for image, title and message.